### PR TITLE
Size those packets just right

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 before_script:
 - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 before_install:
-- rvm install ruby-2.3.0
-- rvm use 2.3.0
+- rvm install ruby-2.3.1
+- rvm use 2.3.1
 - bundle install
 after_success:
 - travis-cargo --only stable doc-upload

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '2.3.0'
+ruby '2.3.1'
 
 gem 'cucumber'

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -6,6 +6,17 @@ use std::net::SocketAddr;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
+/**
+ * Maximum transmission unit of a gaffer payload
+ *
+ * Derived from ethernet_mtu - ipv6_header_size - udp_header_size - gaffer_header_size
+ 1500 - 40 - 8 - 8 = 1452
+ *
+ * This is not strictly guaranteed -- there may be less room in an ethernet frame than this due to
+ * variability in ipv6 header size.
+ */
+pub const GAFFER_MTU: usize = 1452; /* bytes */
+
 /// TODO: consider slice
 pub type GafferPayload = Vec<u8>;
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -10,7 +10,7 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
  * Maximum transmission unit of a gaffer payload
  *
  * Derived from ethernet_mtu - ipv6_header_size - udp_header_size - gaffer_header_size
- 1500 - 40 - 8 - 8 = 1452
+ *       1452 = 1500         - 40               - 8               - 8
  *
  * This is not strictly guaranteed -- there may be less room in an ethernet frame than this due to
  * variability in ipv6 header size.

--- a/src/socket/blocking.rs
+++ b/src/socket/blocking.rs
@@ -24,7 +24,7 @@ impl GafferSocket {
       GafferSocket {
         udp_socket: sock,
         state: GafferState::new(),
-        recv_buffer: [8; 8192]
+        recv_buffer: [0; 8192]
       }
     })
   }

--- a/src/socket/blocking.rs
+++ b/src/socket/blocking.rs
@@ -2,7 +2,8 @@ use addr::ToSingleSocketAddr;
 
 use packet::{
   CompleteGafferPacket,
-  GafferPacket
+  GafferPacket,
+  GAFFER_MTU,
 };
 
 use socket::GafferState;
@@ -14,7 +15,7 @@ use std::net::UdpSocket;
 pub struct GafferSocket {
   udp_socket: UdpSocket,
   state: GafferState,
-  recv_buffer: [u8; 8192]
+  recv_buffer: [u8; GAFFER_MTU],
 }
 
 impl GafferSocket {
@@ -24,7 +25,7 @@ impl GafferSocket {
       GafferSocket {
         udp_socket: sock,
         state: GafferState::new(),
-        recv_buffer: [0; 8192]
+        recv_buffer: [0; GAFFER_MTU]
       }
     })
   }

--- a/src/socket/blocking.rs
+++ b/src/socket/blocking.rs
@@ -13,7 +13,8 @@ use std::net::UdpSocket;
 
 pub struct GafferSocket {
   udp_socket: UdpSocket,
-  state: GafferState
+  state: GafferState,
+  recv_buffer: [u8; 8192]
 }
 
 impl GafferSocket {
@@ -22,7 +23,8 @@ impl GafferSocket {
     UdpSocket::bind(&first_addr).map(|sock| {
       GafferSocket {
         udp_socket: sock,
-        state: GafferState::new()
+        state: GafferState::new(),
+        recv_buffer: [8; 8192]
       }
     })
   }
@@ -35,10 +37,11 @@ impl GafferSocket {
   /// - Forget own acked packets
   /// - Enqueue Sure-Dropped packets into resubmit-queue
   pub fn recv(&mut self) -> io::Result<GafferPacket> {
-    let mut res = [0; 1024];
-    self.udp_socket.recv_from(&mut res)
+    let output = self.udp_socket.recv_from(&mut self.recv_buffer);
+
+    output
       // TODO: Fix to_vec, it is suboptimal here
-      .and_then(|(_, addr)| CompleteGafferPacket::deserialize(res.to_vec()).map(|res| (addr, res)) )
+      .and_then(|(len, addr)| CompleteGafferPacket::deserialize(self.recv_buffer[..len].to_vec()).map(|res| (addr, res)) )
       .map(|(addr, packet)| self.state.receive(addr, packet))
   }
 

--- a/src/socket/blocking.rs
+++ b/src/socket/blocking.rs
@@ -37,9 +37,7 @@ impl GafferSocket {
   /// - Forget own acked packets
   /// - Enqueue Sure-Dropped packets into resubmit-queue
   pub fn recv(&mut self) -> io::Result<GafferPacket> {
-    let output = self.udp_socket.recv_from(&mut self.recv_buffer);
-
-    output
+    self.udp_socket.recv_from(&mut self.recv_buffer)
       // TODO: Fix to_vec, it is suboptimal here
       .and_then(|(len, addr)| CompleteGafferPacket::deserialize(self.recv_buffer[..len].to_vec()).map(|res| (addr, res)) )
       .map(|(addr, packet)| self.state.receive(addr, packet))

--- a/src/socket/non_blocking.rs
+++ b/src/socket/non_blocking.rs
@@ -7,14 +7,15 @@ use addr::ToSingleSocketAddr;
 
 use packet::{
   CompleteGafferPacket,
-  GafferPacket
+  GafferPacket,
+  GAFFER_MTU,
 };
 
 #[allow(dead_code)]
 pub struct GafferSocket {
   udp_socket: UdpSocket,
   state: GafferState,
-  recv_buffer: [u8; 8192]
+  recv_buffer: [u8; GAFFER_MTU]
 }
 
 impl GafferSocket {
@@ -24,7 +25,7 @@ impl GafferSocket {
       GafferSocket {
         udp_socket: sock,
         state: GafferState::new(),
-        recv_buffer: [0; 8192]
+        recv_buffer: [0; GAFFER_MTU]
       }
     })
   }

--- a/src/socket/non_blocking.rs
+++ b/src/socket/non_blocking.rs
@@ -24,7 +24,7 @@ impl GafferSocket {
       GafferSocket {
         udp_socket: sock,
         state: GafferState::new(),
-        recv_buffer: [8; 8192]
+        recv_buffer: [0; 8192]
       }
     })
   }

--- a/src/socket/non_blocking.rs
+++ b/src/socket/non_blocking.rs
@@ -37,13 +37,11 @@ impl GafferSocket {
   /// - Forget own acked packets
   /// - Enqueue Sure-Dropped packets into resubmit-queue
   pub fn recv(&mut self) -> io::Result<Option<GafferPacket>> {
-    let output = self.udp_socket.recv_from(&mut self.recv_buffer);
-
-    output
-      // TODO: Fix to_vec, it is suboptimal here
+    self.udp_socket.recv_from(&mut self.recv_buffer)
       .and_then(|opt| {
         match opt {
           Some((len, addr)) => {
+            // TODO: Fix to_vec, it is suboptimal here
             CompleteGafferPacket::deserialize(self.recv_buffer[..len].to_vec())
               .map(|packet| Some(self.state.receive(addr, packet)))
           },


### PR DESCRIPTION
This stops gaffer_udp from padding packets up to 1024, and also allows it to support packet sized up to 8kb.

@wmedrano
@hestela

pls rev